### PR TITLE
Ticket: HCM-1134

### DIFF
--- a/apps/health_campaign_field_worker_app/lib/pages/beneficiary/household_overview.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/beneficiary/household_overview.dart
@@ -693,9 +693,11 @@ class _HouseholdOverviewPageState
                                 projectBeneficiaryType: beneficiaryType,
                               ),
                             );
+                            // TODO: removed the Beneficiaryoute from the flow distributor task
 
-                            await context.router
-                                .push(BeneficiaryDetailsRoute());
+                            // await context.router
+                            //     .push(BeneficiaryDetailsRoute());
+                            context.router.push(DeliverInterventionRoute());
                           },
                           child: Center(
                             child: Text(

--- a/apps/health_campaign_field_worker_app/lib/pages/beneficiary/widgets/splash_acknowledgement.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/beneficiary/widgets/splash_acknowledgement.dart
@@ -2,10 +2,12 @@ import 'dart:async';
 
 import 'package:digit_components/digit_components.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../blocs/household_overview/household_overview.dart';
 
 import '../../../router/app_router.dart';
-import '../../../widgets/localized.dart';
 import '../../../utils/i18_key_constants.dart' as i18;
+import '../../../widgets/localized.dart';
 
 class SplashAcknowledgementPage extends LocalizedStatefulWidget {
   final bool? enableBackToSearch;
@@ -45,6 +47,20 @@ class _SplashAcknowledgementPageState
         action: () {
           context.router.pop();
         },
+        secondaryAction: () {
+          final wrapper = context
+              .read<HouseholdOverviewBloc>()
+              .state
+              .householdMemberWrapper;
+
+          context.router.popAndPush(
+            BeneficiaryWrapperRoute(wrapper: wrapper),
+          );
+        },
+        enableViewHousehold: true,
+        secondaryLabel: localizations.translate(
+          i18.householdDetails.viewHouseHoldDetailsAction,
+        ),
         enableBackToSearch: widget.enableBackToSearch ?? true,
         actionLabel:
             localizations.translate(i18.acknowledgementSuccess.actionLabelText),

--- a/apps/health_campaign_field_worker_app/lib/pages/inventory/record_stock/stock_details.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/inventory/record_stock/stock_details.dart
@@ -515,6 +515,7 @@ class _StockDetailsPageState extends LocalizedState<StockDetailsPage> {
                               },
                             ),
                             DigitTextFormField(
+                              keyboardType: TextInputType.number,
                               label: localizations.translate(
                                 i18.stockDetails
                                     .quantityOfProductIndicatedOnWaybillLabel,

--- a/apps/health_campaign_field_worker_app/lib/widgets/beneficiary/beneficiary_card.dart
+++ b/apps/health_campaign_field_worker_app/lib/widgets/beneficiary/beneficiary_card.dart
@@ -37,7 +37,8 @@ class BeneficiaryCard extends StatelessWidget {
         ),
         Offstage(
           offstage: status == null,
-          child: status == Status.delivered.toValue()
+          child: (status == Status.delivered.toValue() ||
+                  status == Status.visited.toValue())
               ? DigitIconButton(
                   icon: Icons.check_circle,
                   iconText:

--- a/apps/health_campaign_field_worker_app/lib/widgets/beneficiary/view_beneficiary_card.dart
+++ b/apps/health_campaign_field_worker_app/lib/widgets/beneficiary/view_beneficiary_card.dart
@@ -81,10 +81,13 @@ class _ViewBeneficiaryCardState extends LocalizedState<ViewBeneficiaryCard> {
         cellKey: 'gender',
       ),
     ];
-    final filteredHeaderList = context.beneficiaryType !=
-            BeneficiaryType.individual
-        ? headerList.where((element) => element.cellKey != 'delivery' && element.cellKey != 'age').toList()
-        : headerList;
+    final filteredHeaderList =
+        context.beneficiaryType != BeneficiaryType.individual
+            ? headerList
+                .where((element) =>
+                    element.cellKey != 'delivery' && element.cellKey != 'age')
+                .toList()
+            : headerList;
     final bloc = context.read<ProjectBloc>().state;
     final currentCycle = bloc.projectType?.cycles?.firstWhereOrNull(
       (e) =>
@@ -124,14 +127,20 @@ class _ViewBeneficiaryCardState extends LocalizedState<ViewBeneficiaryCard> {
                 .toList()
             : null;
         final ageInYears = DigitDateUtils.calculateAge(
-          e.dateOfBirth != null ? DigitDateUtils.getFormattedDateToDateTime(
-            e.dateOfBirth!,
-          ) ?? DateTime.now() : DateTime.now(),
+          e.dateOfBirth != null
+              ? DigitDateUtils.getFormattedDateToDateTime(
+                    e.dateOfBirth!,
+                  ) ??
+                  DateTime.now()
+              : DateTime.now(),
         ).years;
         final ageInMonths = DigitDateUtils.calculateAge(
-          e.dateOfBirth != null ? DigitDateUtils.getFormattedDateToDateTime(
-            e.dateOfBirth!,
-          ) ?? DateTime.now() : DateTime.now(),
+          e.dateOfBirth != null
+              ? DigitDateUtils.getFormattedDateToDateTime(
+                    e.dateOfBirth!,
+                  ) ??
+                  DateTime.now()
+              : DateTime.now(),
         ).months;
 
         final isNotEligible = !checkEligibilityForAgeAndSideEffect(
@@ -224,7 +233,8 @@ class _ViewBeneficiaryCardState extends LocalizedState<ViewBeneficiaryCard> {
         return TableDataRow(
           context.beneficiaryType != BeneficiaryType.individual
               ? rowTableData
-                  .where((element) => element.cellKey != 'delivery' && element.cellKey != 'age')
+                  .where((element) =>
+                      element.cellKey != 'delivery' && element.cellKey != 'age')
                   .toList()
               : rowTableData,
         );
@@ -233,14 +243,20 @@ class _ViewBeneficiaryCardState extends LocalizedState<ViewBeneficiaryCard> {
     ).toList();
 
     final ageInYears = DigitDateUtils.calculateAge(
-      householdMember.headOfHousehold.dateOfBirth != null ? DigitDateUtils.getFormattedDateToDateTime(
-            householdMember.headOfHousehold.dateOfBirth!,
-          ) ?? DateTime.now() : DateTime.now(),
+      householdMember.headOfHousehold.dateOfBirth != null
+          ? DigitDateUtils.getFormattedDateToDateTime(
+                householdMember.headOfHousehold.dateOfBirth!,
+              ) ??
+              DateTime.now()
+          : DateTime.now(),
     ).years;
     final ageInMonths = DigitDateUtils.calculateAge(
-      householdMember.headOfHousehold.dateOfBirth != null ? DigitDateUtils.getFormattedDateToDateTime(
-            householdMember.headOfHousehold.dateOfBirth!,
-          ) ?? DateTime.now() : DateTime.now(),
+      householdMember.headOfHousehold.dateOfBirth != null
+          ? DigitDateUtils.getFormattedDateToDateTime(
+                householdMember.headOfHousehold.dateOfBirth!,
+              ) ??
+              DateTime.now()
+          : DateTime.now(),
     ).months;
 
     final isNotEligible = !checkEligibilityForAgeAndSideEffect(
@@ -288,11 +304,7 @@ class _ViewBeneficiaryCardState extends LocalizedState<ViewBeneficiaryCard> {
                       ? '${householdMember.members.length ?? 1} ${householdMember.members.length == 1 ? localizations.translate(i18.memberCard.householdMemberText) : localizations.translate(i18.memberCard.householdMembersText)}  \n ${((widget.distance!) * 1000).round() > 999 ? '(${((widget.distance!).round())} km)' : '(${((widget.distance!) * 1000).round()} mts) ${localizations.translate(i18.beneficiaryDetails.fromCurrentLocation)}'}'
                       : '${householdMember.members.length ?? 1} ${householdMember.members.length == 1 ? localizations.translate(i18.memberCard.householdMemberText) : localizations.translate(i18.memberCard.householdMembersText)}',
                   status: context.beneficiaryType != BeneficiaryType.individual
-                      ? (householdMember.tasks ?? []).isNotEmpty &&
-                              !isNotEligible &&
-                              !isBeneficiaryRefused &&
-                              !isBeneficiaryIneligible &&
-                              !isBeneficiaryReferred
+                      ? (householdMember.tasks ?? []).isNotEmpty
                           ? Status.visited.toValue()
                           : Status.notVisited.toValue()
                       : null,


### PR DESCRIPTION
1.Add the localization in login screen.(LOGIN_ERROR)

2.Add the localization for scan screen SAVE_SCANNED_RESOURCE

3. Need to remove one screen in distributor screen “HOUSEHOLD“ and “BENEFICIARY DETAILS”  . 

4.Even after visited also . if we search that user it is still showing “not visited“ status. if I open the card it is showing visited.

5.Need to change Date of Loss to Date of Variance in US Details Screen stock screen.

6. Need to change Record the list of resources lost during campaign operations to Record the stock variance during campaign operations.

7. Even after entering the value in “Quantity indicated on waybill“

8.Need to add the “view household details” button in Data Recorder Successful 